### PR TITLE
fix: text color for filename

### DIFF
--- a/docs/app/components/code-block.tsx
+++ b/docs/app/components/code-block.tsx
@@ -194,7 +194,7 @@ export function CodeBlock({
     >
       <div className="flex items-center justify-between px-4 py-2 text-sm border-b border-zinc-800">
         {filename && (
-          <span className="font-medium text-sm text-foreground/90">
+          <span className="font-medium text-sm text-muted-foreground">
             {filename}
           </span>
         )}


### PR DESCRIPTION
Makes the filename visible. Otherwise it's dark text on dark text.

Current (text exists but not visible):
<img width="833" alt="Screenshot 2025-04-14 at 10 05 10 AM" src="https://github.com/user-attachments/assets/f4602668-ca92-48a2-b20c-e48031efeeff" />


Fixed:
<img width="833" alt="Screenshot 2025-04-14 at 10 04 32 AM" src="https://github.com/user-attachments/assets/d9e344a5-8538-41c8-b776-68c84afdbab5" />
