### PR TITLE
Fix cookie expiration

### DIFF
--- a/src/react/clientPlugin.ts
+++ b/src/react/clientPlugin.ts
@@ -49,7 +49,7 @@ export function getSetCookie(header: string, prevCookie?: string) {
     const expires = expiresAt
       ? new Date(String(expiresAt))
       : maxAge
-        ? new Date(Date.now() + Number(maxAge))
+        ? new Date(Date.now() + Number(maxAge) * 1000)
         : null;
     toSetCookie[key] = {
       value: cookie["value"],


### PR DESCRIPTION
Date.now() is in milliseconds, but the cookie expiration is in seconds.