### PR TITLE
Fix the version of the `convex` peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   },
   "peerDependencies": {
     "better-auth": "1.2.7",
-    "convex": "~1.16.5 || >=1.17.0 <1.25.0"
+    "convex": "~1.16.5 || >=1.17.0 <1.35.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",


### PR DESCRIPTION
We had `<1.25.0` here to allow for future changes to the component authoring APIs, but since these aren’t ready and 1.25 will be released soon we’re bumping all components.